### PR TITLE
Default contact sensor battery value to 100% when unknown

### DIFF
--- a/lib/device_set.js
+++ b/lib/device_set.js
@@ -194,7 +194,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
     }
 
     contactBatteryLevelValue() {
-      return this.data.BatteryLevel || 1
+      return this.data.BatteryLevel || 100
     }
 
     notify() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-vivint",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-vivint",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Control Vivint with HomeBridge",
   "license": "ISC",
   "author": "Tim Harper <timcharper@gmail.com>",


### PR DESCRIPTION
Resolves an issue when using non-Vivint-branded contact sensors, where battery level is always reported as 1%. This forces the plugin to always report to HomeKit as low battery even with the low-battery config parameter is set to 0, because `parseInt(0)` will fall back to the current default `contactBatteryLevelValue()` of 1.