### PR TITLE
fix: change vivint api host

### DIFF
--- a/lib/vivint_api.js
+++ b/lib/vivint_api.js
@@ -6,7 +6,7 @@ const jpegExtract = require('jpeg-extract')
 const VivintDict = require("./vivint_dictionary.json")
 
 const PUBNUB_KEY = 'sub-c-6fb03d68-6a78-11e2-ae8f-12313f022c90'
-const VIVINT_URL = 'https://vivintsky.com/api'
+const VIVINT_URL = 'https://www.vivintsky.com/api'
 
 function VivintApiModule(config, log) {
   class VivintApi {


### PR DESCRIPTION
Several users have been getting errors from Cloudflare due to needing `www` in the API url. This amends the url to contain the correct constant.

https://github.com/balansse/homebridge-vivint/issues/37#issuecomment-913183556