### PR TITLE
Fixing broken Github links

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/@balansse/homebridge-vivint.git"
+    "url": "git://github.com/balansse/homebridge-vivint.git"
   },
   "bugs": {
-    "url": "http://github.com/@balansse/homebridge-vivint/issues"
+    "url": "http://github.com/balansse/homebridge-vivint/issues"
   },
   "engines": {
     "node": ">=10",
@@ -39,7 +39,7 @@
     "fs-extra": "^10.0.0",
     "mocha": "^5.2.0"
   },
-  "homepage": "https://github.com/@balansse/homebridge-vivint#readme",
+  "homepage": "https://github.com/balansse/homebridge-vivint#readme",
   "funding": [
     {
       "type": "kofi",


### PR DESCRIPTION
I accidentally introduced this error.
This fixes the broken link in to the github page on the homebridge plugins page.
It will also fix broken links on the npmjs page.