### PR TITLE
Fix dimmer switch debouncing

### DIFF
--- a/lib/accessories/dimmer_switch.js
+++ b/lib/accessories/dimmer_switch.js
@@ -12,15 +12,7 @@ class DimmerSwitch extends Device {
           leading: true
         })
         return (value, next) => {
-          boundDebounced(value).then(
-            (result) => {
-              next()
-            },
-            (failure) => {
-              log.error("Failure setting dimmer switch state:", failure)
-              next(failure)
-            }
-          )
+          boundDebounced(value, next)
         }
       }
 


### PR DESCRIPTION
Homebridge was crashing when attempting to change the value of a dimmer switch (issue #57). The next callback wasn't being passed to the debounced function. It also looks like next was being called in both setSwitchCurrentValue and the debounced function.