### PR TITLE
Add support for fan rotation speed

### DIFF
--- a/lib/accessories/dimmer_switch.js
+++ b/lib/accessories/dimmer_switch.js
@@ -16,17 +16,26 @@ class DimmerSwitch extends Device {
         }
       }
 
-      this.service = accessory.getService(this.Service.Lightbulb)
+      this.service = accessory.getService(this.Service.Lightbulb) || accessory.getService(this.Service.Fan)
 
       this.service
         .getCharacteristic(this.Characteristic.On)
         .on('get', (next) => next(null, this.switchCurrentValue()))
         .on('set', this.setSwitchCurrentValue.bind(this))
 
-      this.service
-        .getCharacteristic(this.Characteristic.Brightness)
-        .on('get', (next) => next(null, this.switchBrightnessValue()))
-        .on('set', promiseSetter(this.setBrightnessValue.bind(this)))
+      if (accessory.context.name.match(/\bfan\b/i)) {
+        this.is_fan = true
+        this.service
+          .getCharacteristic(this.Characteristic.RotationSpeed)
+          .on('get', (next) => next(null, this.switchBrightnessValue()))
+          .on('set', promiseSetter(this.setBrightnessValue.bind(this)))
+       } else {
+        this.is_fan = false
+        this.service
+          .getCharacteristic(this.Characteristic.Brightness)
+          .on('get', (next) => next(null, this.switchBrightnessValue()))
+          .on('set', promiseSetter(this.setBrightnessValue.bind(this)))
+      }
 
       this.last_val_s = null
       this.last_val = null
@@ -88,9 +97,15 @@ class DimmerSwitch extends Device {
         if (this.data.Value !== this.last_val) {
           // dimmer level has changed, update HomeKit
           this.last_val = this.data.Value
-          this.service
-            .getCharacteristic(this.Characteristic.Brightness)
-            .updateValue(this.data.Value)
+          if (this.is_fan) {
+            this.service
+              .getCharacteristic(this.Characteristic.RotationSpeed)
+              .updateValue(this.data.Value)
+          } else {
+            this.service
+              .getCharacteristic(this.Characteristic.Brightness)
+              .updateValue(this.data.Value)
+          }
         }
 
         if (this.data.Status !== this.last_val_s) {
@@ -112,8 +127,11 @@ class DimmerSwitch extends Device {
     }
 
     static addServices(accessory, Service) {
-      //assuming this is a dimmer switch controlling a light
-      accessory.addService(new Service.Lightbulb(accessory.context.name))
+      if (accessory.context.name.match(/\bfan\b/i)) {
+        accessory.addService(new Service.Fan(accessory.context.name))
+      } else {
+        accessory.addService(new Service.Lightbulb(accessory.context.name))
+      }
     }
   }
 


### PR DESCRIPTION
Smart fan controls show up as dimmer switches in the Vivint panel. This allows HomeKit to show these devices as fans.

I saw that light_switch.js uses the accessory name to choose a service, so I used the same logic here.