### PR TITLE
Handle session cookies by adding a filter on cookie name

### DIFF
--- a/lib/vivint_api.js
+++ b/lib/vivint_api.js
@@ -162,10 +162,12 @@ function VivintApiModule(config, log) {
       })
 
       let sessionInfo = mapObject(JSON.parse(requestResult.body), VivintDict)
-      //let refreshToken = requestResult.headers["set-cookie"][0].split(";")[0] //Removed 10/20/2023 because vivint stopped sending set-cookie header in response
-      //log.info("doAuth old refreshToken = " + creds.refreshToken)
-      //log.info("doAuth new refreshToken = " + refreshToken)
-      //creds.refreshToken = refreshToken; //added to update creds refreshToken if vivint sends a new one
+      let refreshToken = requestResult.headers["set-cookie"].filter((cookie) => cookie.startsWith("s="))[0];
+      if (refreshToken) {
+        //log.info("doAuth old refreshToken = " + creds.refreshToken)
+        //log.info("doAuth new refreshToken = " + refreshToken)
+        creds.refreshToken = refreshToken.split(";")[0]; //added to update creds refreshToken if vivint sends a new one
+      }
       return {sessionInfo: sessionInfo, refreshToken: creds.refreshToken} // 10/20/2023 changed to return creds.refreshToken instead of refreshToken
     }
     catch (err) {

--- a/lib/vivint_mfa.js
+++ b/lib/vivint_mfa.js
@@ -25,7 +25,7 @@ class VivintMFA {
                 resolveWithFullResponse: true
             });
             //console.log("loginResponse = " + JSON.stringify(loginResponse, null, 4));
-            this.refreshToken = loginResponse.headers["set-cookie"][0].filter((cookie) => cookie.startsWith("s="))[0];
+            this.refreshToken = loginResponse.headers["set-cookie"].filter((cookie) => cookie.startsWith("s="))[0];
             if (!this.refreshToken) {
                 throw new Error("Failed to retrieve session cookie!");
             }

--- a/lib/vivint_mfa.js
+++ b/lib/vivint_mfa.js
@@ -25,7 +25,11 @@ class VivintMFA {
                 resolveWithFullResponse: true
             });
             //console.log("loginResponse = " + JSON.stringify(loginResponse, null, 4));
-            this.refreshToken = loginResponse.headers["set-cookie"][0].split(";")[0];
+            this.refreshToken = loginResponse.headers["set-cookie"][0].filter((cookie) => cookie.startsWith("s="))[0];
+            if (!this.refreshToken) {
+                throw new Error("Failed to retrieve session cookie!");
+            }
+            this.refreshToken = this.refreshToken.split(";")[0];
             //Make request to the Authuser URL to trigger MFA token to send
             const authResponse = await request({
                 method: "GET",
@@ -36,7 +40,10 @@ class VivintMFA {
                 simple: false //This allows us to receive a response even if it failed with 401 etc.
             });
             //console.log("authResponse = " + JSON.stringify(authResponse, null, 4));
-            //this.refreshToken = authResponse.headers["set-cookie"][0].split(";")[0]; //Removed 10/20/2023 because vivint stopped sending set-cookie header in response
+            let newRefreshToken = authResponse.headers["set-cookie"].filter((cookie) => cookie.startsWith("s="))[0];
+            if (newRefreshToken) {
+              this.refreshToken = newRefreshToken.split(";")[0];
+            }
             //console.log("refreshToken = " + this.refreshToken);
             if (authResponse.statusCode === 401) {
                 this.using2fa = true;

--- a/scripts/vivint_mfa_cli.js
+++ b/scripts/vivint_mfa_cli.js
@@ -28,7 +28,11 @@ const run = async () => {
       resolveWithFullResponse: true
     });
     //console.log("Response = " + JSON.stringify(response, null, 4));
-    refreshToken = response.headers["set-cookie"][0].split(";")[0];
+    refreshToken = response.headers["set-cookie"][0].filter((cookie) => cookie.startsWith("s="))[0];
+    if (!refreshToken) {
+        throw new Error("Failed to retrieve session cookie!");
+    }
+    refreshToken = refreshToken.split(";")[0];
   } catch (error) {
     console.error(error);
   }

--- a/scripts/vivint_mfa_cli.js
+++ b/scripts/vivint_mfa_cli.js
@@ -48,7 +48,10 @@ const run = async () => {
       simple: false //This allows us to receive a response even if it failed with 401 etc
     });
     //console.log("Response = " + JSON.stringify(response, null, 4));
-    refreshToken = response.headers["set-cookie"][0].split(";")[0];
+    let newRefreshToken = response.headers["set-cookie"].filter((cookie) => cookie.startsWith("s="))[0];
+    if (newRefreshToken) {
+      refreshToken = newRefreshToken.split(";")[0];
+    }
     if (response.statusCode === 401) {
       isMfa = true;
     } else {

--- a/scripts/vivint_mfa_cli.js
+++ b/scripts/vivint_mfa_cli.js
@@ -28,7 +28,7 @@ const run = async () => {
       resolveWithFullResponse: true
     });
     //console.log("Response = " + JSON.stringify(response, null, 4));
-    refreshToken = response.headers["set-cookie"][0].filter((cookie) => cookie.startsWith("s="))[0];
+    refreshToken = response.headers["set-cookie"].filter((cookie) => cookie.startsWith("s="))[0];
     if (!refreshToken) {
         throw new Error("Failed to retrieve session cookie!");
     }


### PR DESCRIPTION
Vivint is now sending an extra cookie for every request. This means that trying to grab the first cookie isn't always guaranteed to grab the session cookie. In order to fix this, I added a filter to find the Set-Cookie headers that start with s=. This will make sure to only grab the correct cookie, ignoring any other cookies that may get added.