### PR TITLE
Add Lighting Groups to Accessories

### DIFF
--- a/lib/accessories/light_group.js
+++ b/lib/accessories/light_group.js
@@ -1,0 +1,141 @@
+const Device = require('../device.js')
+const VivintDict = require("../vivint_dictionary.json")
+const debounce = require("debounce-promise")
+
+class LightGroup extends Device {
+  constructor(accessory, data, config, log, homebridge, vivintApi) {
+    super(accessory, data, config, log, homebridge, vivintApi)
+
+    let self = this
+      let promiseSetter = function(fn) {
+        let boundDebounced = debounce(fn.bind(self), 500, {
+          leading: true
+        })
+        return (value, next) => {
+          boundDebounced(value, next)
+        }
+      }
+
+      this.service = accessory.getService(this.Service.Lightbulb) || accessory.getService(this.Service.Fan)
+
+      this.service
+        .getCharacteristic(this.Characteristic.On)
+        .on('get', (next) => next(null, this.switchCurrentValue()))
+        .on('set', this.setSwitchCurrentValue.bind(this))
+
+      if (accessory.context.name.match(/\bfan\b/i)) {
+        this.is_fan = true
+        this.service
+            .getCharacteristic(this.Characteristic.RotationSpeed)
+            .on('get', (next) => next(null, this.switchBrightnessValue()))
+            .on('set', promiseSetter(this.setBrightnessValue.bind(this)))
+        } else {
+        this.is_fan = false
+        this.service
+            .getCharacteristic(this.Characteristic.Brightness)
+            .on('get', (next) => next(null, this.switchBrightnessValue()))
+            .on('set', promiseSetter(this.setBrightnessValue.bind(this)))
+      }
+
+      this.last_val_s = null
+      this.last_val = null
+    }
+
+    switchCurrentValue() {
+      return this.data.Status
+    }
+
+    setSwitchCurrentValue(targetState, next) {
+      if (targetState) {
+        // turn switch on
+        this.vivintApi.putDevice('switches', this.id, {
+            s: true,
+            _id: this.id
+          })
+          .then(
+            (success) => next(),
+            (failure) => {
+              this.log.error("Failure setting lighting group state:", failure)
+              next(failure)
+            })
+      } else {
+        // turn switch off
+        this.vivintApi.putDevice('switches', this.id, {
+            s: false,
+            _id: this.id
+          })
+          .then(
+            (success) => next(),
+            (failure) => {
+              this.log.error("Failure setting lighting group state:", failure)
+              next(failure)
+            })
+      }
+    }
+
+    switchBrightnessValue() {
+      return this.data.Value
+    }
+
+    setBrightnessValue(targetState, next) {
+      this.vivintApi.putDevice('switches', this.id, {
+          val: targetState,
+          _id: this.id
+        })
+        .then(
+          (success) => next(),
+          (failure) => {
+            this.log.error("Failure setting dimmer brightness state:", failure)
+            next(failure)
+          })
+    }
+
+    notify() {
+      // vivint will typically send two notifications
+
+      if (this.service) {
+        if (this.data.Value !== this.last_val) {
+          // light group level has changed, update HomeKit
+          this.last_val = this.data.Value
+          if (this.is_fan) {
+            this.service
+              .getCharacteristic(this.Characteristic.RotationSpeed)
+              .updateValue(this.data.Value)
+          } else {
+            this.service
+              .getCharacteristic(this.Characteristic.Brightness)
+              .updateValue(this.data.Value)
+          }
+        }
+
+        if (this.data.Status !== this.last_val_s) {
+          // on/off state has changed, update HomeKit
+          this.last_val_s = this.data.Status
+          this.service
+            .getCharacteristic(this.Characteristic.On)
+            .updateValue(this.switchCurrentValue())
+        }
+      }
+    }
+
+    static appliesTo(data) {
+      return data.Type == VivintDict.PanelDeviceType.GroupDevices &&
+        data.panel_capability_types &&
+        data.panel_capability_types.includes(VivintDict.PanelCapabilityType.Dimmable) &&
+        data.panel_capability_types.includes(VivintDict.PanelCapabilityType.GroupDevices)
+    }
+
+    static inferCategory(data, Accessory) {
+      return Accessory.Categories.SWITCH
+    }
+
+    static addServices(accessory, Service) {
+      if (accessory.context.name.match(/\bfan\b/i)) {
+        accessory.addService(new Service.Fan(accessory.context.name))
+      } else {
+        accessory.addService(new Service.Lightbulb(accessory.context.name))
+      }
+    }
+  }
+
+module.exports = LightGroup

--- a/lib/device_set.js
+++ b/lib/device_set.js
@@ -11,6 +11,7 @@ const Panel = require("./accessories/panel.js")
 const Camera = require("./accessories/camera.js")
 const LightSwitch = require("./accessories/light_switch.js")
 const DimmerSwitch = require("./accessories/dimmer_switch.js")
+const LightGroup = require("./accessories/light_group.js")
 
 function DeviceSetModule(config, log, homebridge, vivintApi) {
   let PlatformAccessory = homebridge.platformAccessory
@@ -184,7 +185,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi) {
     }
   }
 
-  let Devices = [ContactSensor, SmokeSensor, CarbonMonoxideSensor, MotionSensor, Lock, Thermostat, GarageDoor, Panel, Camera, LightSwitch, DimmerSwitch]
+  let Devices = [ContactSensor, SmokeSensor, CarbonMonoxideSensor, MotionSensor, Lock, Thermostat, GarageDoor, Panel, Camera, LightSwitch, DimmerSwitch, LightGroup]
   return DeviceSet
 }
 

--- a/lib/vivint_dictionary.json
+++ b/lib/vivint_dictionary.json
@@ -381,7 +381,8 @@
         "HueBridge": "phillips_hue_bridge_device",
         "PersonalGuardDevice": "personal_guard_device",
         "PODNestThermostat": "pod_nest_thermostat_device",
-        "PODMyQGarageDoorDevice": "pod_myq_garage_door_device"
+        "PODMyQGarageDoorDevice": "pod_myq_garage_door_device",
+        "GroupDevices": "group_device"
     },
     "WeekdayType": {
         "Weekday": "weekday",
@@ -4269,6 +4270,10 @@
         "MaxCoolLockSetPoint": 69,
         "MinCoolLockSetPoint": 70,
         "DoorState": 71
+    },
+    "PanelCapabilityType": {
+        "Dimmable": 8,
+        "GroupDevices": 17
     },
     "Operators": {
         "UpdateAll": "ua",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balansse/homebridge-vivint",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Control Vivint with HomeBridge",
   "license": "ISC",
   "author": "Alexandr Balan <balansse@gmail.com>",


### PR DESCRIPTION
Hi, I'm a Vivint employee. Last year, Vivint rolled out new WiFi light bulbs. One of the device types created was a "lighting group." This change allows Homekit to control a Vivint group of lights.